### PR TITLE
Standardize variables

### DIFF
--- a/lib/builtins/bookmark.sh
+++ b/lib/builtins/bookmark.sh
@@ -18,22 +18,22 @@ task_bookmark() {
   if [[ "$TASK_SUBCOMMAND" == "list" ]]
   then
     echo "Bookmarks:"
-    sed 's/UUID_\(.*\)=.*/    \1/' "$LOCATIONS_FILE" | tr '\n' ' '
+    sed 's/UUID_\(.*\)=.*/    \1/' "$LOCATION_FILE" | tr '\n' ' '
     echo
     echo
   elif [[ "$TASK_SUBCOMMAND" == "rm" ]]
   then
-    if grep -q "UUID_$ARG_NAME=" "$LOCATIONS_FILE"
+    if grep -q "UUID_$ARG_NAME=" "$LOCATION_FILE"
     then
-      awk "/UUID_$ARG_NAME=/ { next } { print }" "$LOCATIONS_FILE" > "$LOCATIONS_FILE.upd"
-      mv "$LOCATIONS_FILE"{.upd,}
+      awk "/UUID_$ARG_NAME=/ { next } { print }" "$LOCATION_FILE" > "$LOCATION_FILE.upd"
+      mv "$LOCATION_FILE"{.upd,}
       echo "Removed bookmark: $ARG_NAME"
     else
       echo "Bookmark $ARG_NAME not found"
     fi
   else
-    echo "Saving location to $LOCATIONS_FILE as $ARG_NAME"
-    echo "UUID_$ARG_NAME=$ARG_DIR" >> "$LOCATIONS_FILE"
+    echo "Saving location to $LOCATION_FILE as $ARG_NAME"
+    echo "UUID_$ARG_NAME=$ARG_DIR" >> "$LOCATION_FILE"
   fi
 }
 

--- a/lib/builtins/edit.sh
+++ b/lib/builtins/edit.sh
@@ -3,32 +3,32 @@ arguments_edit() {
 }
 
 task_edit() {
-  if [[ -z "$TASKS_FILE" ]]
+  if [[ -z "$TASK_FILE" ]]
   then
     echo "No tasks file found."
     return 1
   fi
   source "$DRIVER_DIR/${TASK_DRIVER_DICT[$TASK_FILE_DRIVER]}"
   local validated=1
-  cp "$TASKS_FILE" "$TASKS_FILE.tmp"
+  cp "$TASK_FILE" "$TASK_FILE.tmp"
   while [[ "$validated" != "0" ]]
   do
-    $DEFAULT_EDITOR "$TASKS_FILE"
-    if ! $DRIVER_VALIDATE_TASKS_FILE "$TASKS_FILE"
+    $DEFAULT_EDITOR "$TASK_FILE"
+    if ! $DRIVER_VALIDATE_TASK_FILE "$TASK_FILE"
     then
       validated=1
-      echo "Could not validate $TASKS_FILE."
+      echo "Could not validate $TASK_FILE."
       echo "Changes will be reverted if you choose not to edit again."
       read -rp "Edit again (yes or no)?[yes]" ans
       if [[ "$ans" == "no" ]]
       then
-        mv "$TASKS_FILE.tmp" "$TASKS_FILE"
+        mv "$TASK_FILE.tmp" "$TASK_FILE"
         validated=0
       fi
     else
       echo "Changes validated."
       validated=0
-      rm "$TASKS_FILE.tmp"
+      rm "$TASK_FILE.tmp"
     fi
   done
 }

--- a/lib/builtins/global.sh
+++ b/lib/builtins/global.sh
@@ -72,21 +72,21 @@ global_edit() {
 
 global_clean() {
   echo "Removing nonexistant locations from locations file..."
-  sed 's/.*=\(.*\)/\1/' "$LOCATIONS_FILE" | while IFS= read -r file
+  sed 's/.*=\(.*\)/\1/' "$LOCATION_FILE" | while IFS= read -r file
   do
     if [[ ! -d "$file" ]]
     then
-      grep -v "$file" "$LOCATIONS_FILE" > "$LOCATIONS_FILE.tmp"
-      mv "$LOCATIONS_FILE.tmp" "$LOCATIONS_FILE"
+      grep -v "$file" "$LOCATION_FILE" > "$LOCATION_FILE.tmp"
+      mv "$LOCATION_FILE.tmp" "$LOCATION_FILE"
     fi
   done
 
-  echo "Cleaning state files from tasks files not in $LOCATIONS_FILE"
+  echo "Cleaning state files from tasks files not in $LOCATION_FILE"
   for file in "$TASK_MASTER_HOME/state/"*
   do
     if [[ -d "$file" ]]
     then
-      if ! grep -q "$file" "$LOCATIONS_FILE"
+      if ! grep -q "$file" "$LOCATION_FILE"
       then
         echo "Removing $file..."
         rm -r "$file"

--- a/lib/builtins/global.sh
+++ b/lib/builtins/global.sh
@@ -103,6 +103,7 @@ global_clean() {
   fi
 }
 
+readonly -f arguments_global
 readonly -f task_global
 readonly -f global_debug
 readonly -f global_set

--- a/lib/builtins/goto.sh
+++ b/lib/builtins/goto.sh
@@ -1,16 +1,17 @@
 arguments_goto() {
-  SUBCOMMANDS="$(sed 's/UUID_\(.*\)=.*/\1|/' "$LOCATIONS_FILE" | tr -d "\n")"
+  SUBCOMMANDS="$(sed 's/UUID_\(.*\)=.*/\1|/' "$LOCATION_FILE" | tr -d "\n")"
+  SUBCOMMANDS="${SUBCOMMANDS%?}"
   GOTO_DESCRIPTION="Change directories to a bookmark"
 }
 
 task_goto() {
   var_name=UUID_$TASK_SUBCOMMAND
-  loc_line=$(grep "^$var_name=.*" "$LOCATIONS_FILE" | head -n1 )
+  loc_line=$(grep "^$var_name=.*" "$LOCATION_FILE" | head -n1 )
   if [[ -z "$loc_line" ]]
   then
      echo "Unknown location: $TASK_SUBCOMMAND"
      echo "Available locations are:"
-     sed 's/^UUID_\(.*\)=.*/\1/' "$LOCATIONS_FILE" | tr '\n' ' '
+     sed 's/^UUID_\(.*\)=.*/\1/' "$LOCATION_FILE" | tr '\n' ' '
      echo
      return 0
   fi

--- a/lib/builtins/init.sh
+++ b/lib/builtins/init.sh
@@ -40,10 +40,10 @@ task_init() {
     return 1
   fi
   
-  NEW_TASKS_FILE=$ARG_DIR/$filename
+  NEW_TASK_FILE=$ARG_DIR/$filename
 
   # Check for existing tasks file
-  if [[ -f "$NEW_TASKS_FILE" ]]
+  if [[ -f "$NEW_TASK_FILE" ]]
   then
     echo "Task file already exists can't init in $ARG_DIR"
     return 1

--- a/lib/builtins/list.sh
+++ b/lib/builtins/list.sh
@@ -18,7 +18,7 @@ task_list() {
   if [[ -n "$ARG_LOCAL$ARG_ALL" ]]
   then
     # List is a global task, so we need to load the task file driver
-    source "$DRIVER_DIR/${TASK_DRIVER_DICT[$TASK_FILE_DRIVER]}"
+    source "$DRIVER_DIR/${TASK_DRIVER_DICT[$TASK_FILE_DRIVER]}" &> /dev/null
     echo "Available local tasks:"
     echo
     echo "     $($DRIVER_LIST_TASKS "$TASK_FILE")"

--- a/lib/builtins/list.sh
+++ b/lib/builtins/list.sh
@@ -12,15 +12,16 @@ task_list() {
   then
     echo "Available global tasks:"
     echo
-    echo "    $GLOBAL_TASKS" | sed 's/|/    /g'
+    echo "    $GLOBAL_TASKS_REG" | sed 's/|/    /g'
     echo
   fi
   if [[ -n "$ARG_LOCAL$ARG_ALL" ]]
   then
+    # List is a global task, so we need to load the task file driver
     source "$DRIVER_DIR/${TASK_DRIVER_DICT[$TASK_FILE_DRIVER]}"
     echo "Available local tasks:"
     echo
-    echo "     $($DRIVER_LIST_TASKS "$TASKS_FILE")"
+    echo "     $($DRIVER_LIST_TASKS "$TASK_FILE")"
     echo
   fi
 }

--- a/lib/builtins/module.sh
+++ b/lib/builtins/module.sh
@@ -4,10 +4,10 @@ arguments_module() {
   MODULE_DESCRIPTION="Manage modules."
 
   ENABLE_DESCRIPTION="Enable a module. Downloads modules from TASK_REPOS if not found locally."
-  ENABLE_REQUIREMENTS="id:i:str"
+  ENABLE_REQUIREMENTS="name:n:str"
 
   DISABLE_DESCRIPTION="Disable a module"
-  DISABLE_REQUIREMENTS="id:i:str"
+  DISABLE_REQUIREMENTS="name:n:str"
 
   LIST_DESCRIPTION="List modules"
   LIST_OPTIONS="all:a:bool remote:r:bool enabled:e:bool disabled:d:bool local:l:bool"
@@ -27,43 +27,43 @@ task_module() {
 }
 
 module_enable() {
-  filename="$TASK_MASTER_HOME/modules/$ARG_ID-module.sh"
+  filename="$TASK_MASTER_HOME/modules/$ARG_NAME-module.sh"
   if [[ -f "$filename.disabled" ]]
   then
     # Module already downloaded
-    echo "Enabling $ARG_ID module..."
+    echo "Enabling $ARG_NAME module..."
     mv "$filename"{.disabled,}
   else
     echo Searching repositories...
     for repo in $TASK_REPOS
     do
       inventory=$(curl -s "$repo")
-      module_file=$(echo "$inventory" | grep "module-$ARG_ID" | awk -F '=' '{ print $2 }' | xargs )
+      module_file=$(echo "$inventory" | grep "module-$ARG_NAME" | awk -F '=' '{ print $2 }' | xargs )
       if [[ -n "$module_file" ]]
       then
-        echo "$ARG_ID module found in $repo"
+        echo "$ARG_NAME module found in $repo"
         break
       fi
     done
     if [[ -z "$module_file" ]]
     then
-      echo "Unable to find $ARG_ID module"
+      echo "Unable to find $ARG_NAME module"
       return 1
     fi
     module_dir=$(dirname "$repo")/$(echo "$inventory" | grep MODULE_DIR | awk -F '=' '{ print $2 }' | xargs )
     echo "Downloading $module_dir/$module_file..."
     curl -s "$module_dir/$module_file" >> "$filename"
-    echo "$ARG_ID module installed."
+    echo "$ARG_NAME module installed."
   fi 
 }
 
 module_disable() {
-  if [[ -f "$TASK_MASTER_HOME/modules/$ARG_ID-module.sh" ]]
+  if [[ -f "$TASK_MASTER_HOME/modules/$ARG_NAME-module.sh" ]]
   then
-    echo "Disabling $ARG_ID module..."
-    mv "$TASK_MASTER_HOME/modules/$ARG_ID-module.sh"{,.disabled}
+    echo "Disabling $ARG_NAME module..."
+    mv "$TASK_MASTER_HOME/modules/$ARG_NAME-module.sh"{,.disabled}
   else
-    echo "Could not find $ARG_ID module"
+    echo "Could not find $ARG_NAME module"
     return 1
   fi
 }

--- a/lib/drivers/bash_driver.sh
+++ b/lib/drivers/bash_driver.sh
@@ -286,3 +286,11 @@ execute_task() {
 bash_validate_file() {
   bash -n "$1"
 }
+
+
+readonly -f bash_parse
+readonly -f bash_validate
+readonly -f bash_help
+readonly -f bash_list
+readonly -f execute_task
+readonly -f bash_validate_file

--- a/lib/drivers/bash_driver.sh
+++ b/lib/drivers/bash_driver.sh
@@ -1,7 +1,7 @@
 DRIVER_EXECUTE_TASK=execute_task
 DRIVER_LIST_TASKS=bash_list
 DRIVER_HELP_TASK=bash_help
-DRIVER_VALIDATE_TASKS_FILE=bash_validate_file
+DRIVER_VALIDATE_TASK_FILE=bash_validate_file
 
 bash_parse() {
   # All arguments after the command will be parsed into environment variables
@@ -258,16 +258,16 @@ bash_help() {
 bash_list() {
   if [[ -f "$1" ]]
   then
-    awk '/task_.*(.*).*/ { print }' "$1" | sed 's/.*task_\(.*\)(.*).*/\1 /' | tr -d "\n"
+    awk '/^task_.*(.*).*/ { print }' "$1" | sed 's/.*task_\(.*\)(.*).*/\1 /' | tr -d "\n"
   fi
 }
 
 execute_task() {
   #Load local tasks if the desired task isn't loaded
-  if [[ -n "$TASKS_FILE_FOUND" ]] 
+  if [[ -n "$TASK_FILE_FOUND" ]] 
   then
     _tmverbose_echo "Sourcing tasks file"
-    source "$TASKS_FILE"
+    source "$TASK_FILE"
   fi
 
   #Parse and validate arguments

--- a/load-global.sh
+++ b/load-global.sh
@@ -10,3 +10,5 @@ then
     source "$module"
   done
 fi
+unset enabled
+unset module

--- a/test/lib/builtins/bookmark.bats
+++ b/test/lib/builtins/bookmark.bats
@@ -2,14 +2,14 @@ setup() {
   load "$TASK_MASTER_HOME/test/run/bats-support/load"
   load "$TASK_MASTER_HOME/test/run/bats-assert/load"
 
-  export LOCATIONS_FILE=$TASK_MASTER_HOME/test/locations.bookmark
+  export LOCATION_FILE=$TASK_MASTER_HOME/test/locations.bookmark
   export RUNNING_DIR=$(pwd)
 
-  touch $LOCATIONS_FILE
+  touch $LOCATION_FILE
 }
 
 teardown() {
-  rm $LOCATIONS_FILE
+  rm $TASK_MASTER_HOME/test/locations.bookmark
 }
 
 @test "Create a bookmark" {
@@ -17,7 +17,7 @@ teardown() {
 
   task_bookmark
 
-  run cat $LOCATIONS_FILE
+  run cat $LOCATION_FILE
   assert_output "UUID_test_dir=$TASK_MASTER_HOME/test"
 }
 
@@ -26,26 +26,26 @@ teardown() {
 
   task_bookmark
 
-  run cat $LOCATIONS_FILE
+  run cat $LOCATION_FILE
   assert_output "UUID_test_dir=/tmp"
 }
 
 @test "Remove a bookmark by name" {
   source_and_set_vars "rm" "bkmk"
 
-  echo UUID_bkmk=/home/btm/project > $LOCATIONS_FILE
+  echo UUID_bkmk=/home/btm/project > $LOCATION_FILE
   
   task_bookmark
 
-  run cat $LOCATIONS_FILE
+  run cat $LOCATION_FILE
   assert_output ""
 }
 
 @test "List bookmarks" {
   source_and_set_vars "list"
   
-  echo UUID_proj=/home/btm/project > $LOCATIONS_FILE
-  echo UUID_bkmk=/home/btm/project >> $LOCATIONS_FILE
+  echo UUID_proj=/home/btm/project > $LOCATION_FILE
+  echo UUID_bkmk=/home/btm/project >> $LOCATION_FILE
 
   run task_bookmark
 

--- a/test/lib/builtins/edit.bats
+++ b/test/lib/builtins/edit.bats
@@ -2,15 +2,15 @@ setup() {
   load "$TASK_MASTER_HOME/test/run/bats-support/load"
   load "$TASK_MASTER_HOME/test/run/bats-assert/load"
 
-  export TASKS_FILE=$TASK_MASTER_HOME/test/test_task_file.sh
+  export TASK_FILE=$TASK_MASTER_HOME/test/test_task_file.sh
   export DEFAULT_EDITOR=return_0
-  export DRIVER_VALIDATE_TASKS_FILE="bash -n "
+  export DRIVER_VALIDATE_TASK_FILE="bash -n "
 
-  touch $TASKS_FILE
+  touch $TASK_FILE
 }
 
 teardown() {
-  rm -f $TASKS_FILE
+  rm -f $TASK_FILE
 }
 
 @test "Sets description" {
@@ -23,7 +23,7 @@ teardown() {
 
 @test "Fails if a task file is not found" {
   source $TASK_MASTER_HOME/lib/builtins/edit.sh
-  TASKS_FILE=""
+  TASK_FILE=""
 
   run task_edit
   assert_failure
@@ -40,7 +40,7 @@ teardown() {
 @test "Asks to retry if not validated" {
   source $TASK_MASTER_HOME/lib/builtins/edit.sh
   mess_up_tasks_file
-  DRIVER_VALIDATE_TASKS_FILE=validate_success
+  DRIVER_VALIDATE_TASK_FILE=validate_success
 
   run task_edit <<< "no"
   assert_output --partial "Could not validate"
@@ -53,7 +53,7 @@ teardown() {
   run task_edit <<< "no"
   assert_output --partial "Could not validate"
   
-  run cat $TASKS_FILE
+  run cat $TASK_FILE
   assert_output ""
 }
 
@@ -67,7 +67,7 @@ teardown() {
 }
 
 fix_tasks_file() {
-  cat > $TASKS_FILE <<EOF
+  cat > $TASK_FILE <<EOF
 hello() {
   return 0
 }
@@ -75,7 +75,7 @@ EOF
 }
 
 mess_up_tasks_file() {
-  cat > $TASKS_FILE <<EOF
+  cat > $TASK_FILE <<EOF
 hello() {
   if [[ this == should ]]
     echo missing then

--- a/test/lib/builtins/global.bats
+++ b/test/lib/builtins/global.bats
@@ -2,8 +2,8 @@ setup() {
   load "$TASK_MASTER_HOME/test/run/bats-support/load"
   load "$TASK_MASTER_HOME/test/run/bats-assert/load"
 
-  export LOCATIONS_FILE=$TASK_MASTER_HOME/test/locations.global
-  echo "UUID_tmhome=$TASK_MASTER_HOME" > "$LOCATIONS_FILE"
+  export LOCATION_FILE=$TASK_MASTER_HOME/test/locations.global
+  echo "UUID_tmhome=$TASK_MASTER_HOME" > "$LOCATION_FILE"
 
   export STATE_DIR=$TASK_MASTER_HOME/state
 
@@ -15,7 +15,7 @@ setup() {
 }
 
 teardown() {
-  rm $LOCATIONS_FILE
+  rm $TASK_MASTER_HOME/test/locations.global
   rm $COMMAND_STATE_FILE
   rm $OTHER_STATE_FILE
 }
@@ -84,13 +84,13 @@ teardown() {
 @test 'Clean removes locations from location file that no longer exist' {
   source $TASK_MASTER_HOME/lib/builtins/global.sh
 
-  echo "UUID_hello=$TASK_MASTER_HOME/test/doesnotexist" >> $LOCATIONS_FILE
+  echo "UUID_hello=$TASK_MASTER_HOME/test/doesnotexist" >> $LOCATION_FILE
 
   TASK_SUBCOMMAND="clean"
 
   task_global
 
-  run cat $LOCATIONS_FILE
+  run cat $LOCATION_FILE
 
   assert_output --partial "UUID_tmhome=$TASK_MASTER_HOME"
   refute_output --partial "UUID_hello=$TASK_MASTER_HOME/test/doesnotexist"
@@ -121,7 +121,7 @@ teardown() {
   assert [ ! -f "$TASK_MASTER_HOME/state/empty.vars" ]
 }
 
-@test 'Should define descriptions and arguments' {
+@test 'Defines descriptions and arguments' {
   source $TASK_MASTER_HOME/lib/builtins/global.sh
   
   arguments_global

--- a/test/lib/builtins/goto.bats
+++ b/test/lib/builtins/goto.bats
@@ -2,9 +2,9 @@ setup() {
   load "$TASK_MASTER_HOME/test/run/bats-support/load"
   load "$TASK_MASTER_HOME/test/run/bats-assert/load"
 
-  export LOCATIONS_FILE=$TASK_MASTER_HOME/test/locations.goto
+  export LOCATION_FILE=$TASK_MASTER_HOME/test/locations.goto
 
-  cat > $LOCATIONS_FILE <<EOF
+  cat > $LOCATION_FILE <<EOF
 UUID_tmhome=$TASK_MASTER_HOME
 UUID_project=$TASK_MASTER_HOME/test/proj
 EOF
@@ -16,7 +16,7 @@ EOF
 teardown() {
   cd $TASK_MASTER_HOME/test/
   rmdir $TASK_MASTER_HOME/test/proj
-  rm $LOCATIONS_FILE
+  rm $TASK_MASTER_HOME/test/locations.goto
 }
 
 @test "Sets descripton" {
@@ -27,7 +27,7 @@ teardown() {
   assert [ ! -z "$GOTO_DESCRIPTION" ]
 }
 
-@test "Should goto directory" {
+@test "Changes the current directory" {
   source $TASK_MASTER_HOME/lib/builtins/goto.sh
 
   TASK_SUBCOMMAND="project"
@@ -38,7 +38,7 @@ teardown() {
   assert_output $TASK_MASTER_HOME/test/proj
 }
 
-@test "Should stay when location does not exist" {
+@test "Stays in the current directory when location does not exist" {
   source $TASK_MASTER_HOME/lib/builtins/goto.sh
 
   TASK_SUBCOMMAND="foobar"

--- a/test/lib/builtins/help.bats
+++ b/test/lib/builtins/help.bats
@@ -22,7 +22,7 @@ setup() {
   load "$TASK_MASTER_HOME/test/run/bats-assert/load"
 }
 
-@test 'Should call driver help when driver returns zero' {
+@test 'Calls driver help when driver returns zero' {
   source $TASK_MASTER_HOME/lib/builtins/help.sh
 
   declare -A TASK_DRIVER_DICT
@@ -37,7 +37,7 @@ setup() {
   refute_output --partial "Task Master"
 }
 
-@test 'Should display global help when driver returns non-zero' {
+@test 'Displays global help when driver returns non-zero' {
   source $TASK_MASTER_HOME/lib/builtins/help.sh
   TASK_SUBCOMMAND="chester"
 

--- a/test/lib/builtins/init.bats
+++ b/test/lib/builtins/init.bats
@@ -2,7 +2,7 @@ setup() {
   load "$TASK_MASTER_HOME/test/run/bats-support/load"
   load "$TASK_MASTER_HOME/test/run/bats-assert/load"
 
-  export LOCATIONS_FILE=$TASK_MASTER_HOME/test/locations.init
+  export LOCATION_FILE=$TASK_MASTER_HOME/test/locations.init
   export TEST_DIR=$TASK_MASTER_HOME/test/init_test
   export RUNNING_DIR=$TEST_DIR
   export DEFAULT_TASK_DRIVER=bash
@@ -15,7 +15,7 @@ setup() {
 teardown() {
   echo "OUTPUT:"
   echo "$output"
-  rm -f $LOCATIONS_FILE
+  rm -f $TASK_MASTER_HOME/test/locations.init
   rm -rf $TEST_DIR
   rm -rf $TASK_MASTER_HOME/state/init_test
   rm -rf $TASK_MASTER_HOME/state/project

--- a/test/lib/builtins/list.bats
+++ b/test/lib/builtins/list.bats
@@ -8,7 +8,7 @@ setup() {
 @test 'Lists all tasks by default' {
   source $TASK_MASTER_HOME/lib/builtins/list.sh
 
-  GLOBAL_TASKS="gtask|gtask2"
+  GLOBAL_TASKS_REG="gtask|gtask2"
   run task_list
   assert_output --partial "gtask"
   assert_output --partial "gtask2"
@@ -19,7 +19,7 @@ setup() {
   source $TASK_MASTER_HOME/lib/builtins/list.sh
 
   ARG_GLOBAL=T
-  GLOBAL_TASKS="gtask|gtask2"
+  GLOBAL_TASKS_REG="gtask|gtask2"
 
   run task_list
   assert_output --partial "gtask"
@@ -29,7 +29,7 @@ setup() {
 
 @test 'Lists local tasks when local flag given' {
   source $TASK_MASTER_HOME/lib/builtins/list.sh
-  GLOBAL_TASKS="gtask|gtask2"
+  GLOBAL_TASKS_REG="gtask|gtask2"
   ARG_LOCAL=T
 
   run task_list

--- a/test/lib/builtins/module.bats
+++ b/test/lib/builtins/module.bats
@@ -56,7 +56,7 @@ teardown() {
   source $TASK_MASTER_HOME/lib/builtins/module.sh
   touch $TASK_MASTER_HOME/modules/local-module.sh.disabled
 
-  ARG_ID="local"
+  ARG_NAME="local"
   TASK_SUBCOMMAND="enable"
 
   run task_module
@@ -67,7 +67,7 @@ teardown() {
 @test 'Downloads remote module and enables it' {
   source $TASK_MASTER_HOME/lib/builtins/module.sh
 
-  ARG_ID="test"
+  ARG_NAME="test"
   TASK_SUBCOMMAND="enable"
 
   run task_module
@@ -78,7 +78,7 @@ teardown() {
 @test 'Fails to find a non importable module' { 
   source $TASK_MASTER_HOME/lib/builtins/module.sh
 
-  ARG_ID="missing"
+  ARG_NAME="missing"
   TASK_SUBCOMMAND="enable"
 
   run task_module
@@ -90,7 +90,7 @@ teardown() {
 
   touch $TASK_MASTER_HOME/modules/local-module.sh
 
-  ARG_ID="local"
+  ARG_NAME="local"
   TASK_SUBCOMMAND="disable"
 
   run task_module
@@ -101,7 +101,7 @@ teardown() {
 @test 'Fails to disable module that isnt enabled' {
   source $TASK_MASTER_HOME/lib/builtins/module.sh
 
-  ARG_ID="missing"
+  ARG_NAME="missing"
   TASK_SUBCOMMAND="disable"
 
   run task_module

--- a/test/lib/drivers/bash_driver.bats
+++ b/test/lib/drivers/bash_driver.bats
@@ -1,8 +1,8 @@
 setup() {
   load "$TASK_MASTER_HOME/test/run/bats-support/load"
   load "$TASK_MASTER_HOME/test/run/bats-assert/load"
-  export EXAMPLE_TASKS_FILE=$TASK_MASTER_HOME/test/tasks.sh.bash_driver
-  cat > $EXAMPLE_TASKS_FILE <<EOF
+  export EXAMPLE_TASK_FILE=$TASK_MASTER_HOME/test/tasks.sh.bash_driver
+  cat > $EXAMPLE_TASK_FILE <<EOF
 task_hello() {
   :
 }
@@ -20,7 +20,7 @@ EOF
 }
 
 teardown() {
-  rm $EXAMPLE_TASKS_FILE
+  rm $EXAMPLE_TASK_FILE
 }
 
 @test 'Defines DRIVER_PARSE_ARGS, DRIVER_VALIDATE_ARGS, DRIVER_EXECUTE_TASK, DRIVER_HELP_TASK, ' {
@@ -267,9 +267,9 @@ teardown() {
 @test 'Lists tasks in a task file' {
   source $TASK_MASTER_HOME/lib/drivers/bash_driver.sh
 
-  TASKS_FILE_FOUND=1
+  TASK_FILE_FOUND=1
 
-  run $DRIVER_LIST_TASKS $EXAMPLE_TASKS_FILE
+  run $DRIVER_LIST_TASKS $EXAMPLE_TASK_FILE
   assert_output "hello world foo bar "
   assert_success
 }
@@ -277,16 +277,16 @@ teardown() {
 @test 'Validates tasks file' {
   source $TASK_MASTER_HOME/lib/drivers/bash_driver.sh
 
-  run $DRIVER_VALIDATE_TASKS_FILE $EXAMPLE_TASKS_FILE
+  run $DRIVER_VALIDATE_TASK_FILE $EXAMPLE_TASK_FILE
   assert_success
 }
 
 @test 'Does not validate bad tasks file {
   source $TASK_MASTER_HOME/lib/drivers/bash_driver.sh
-  grep -v task_bar $EXAMPLE_TASKS_FILE > $EXAMPLE_TASKS_FILE.tmp
-  mv $EXAMPLE_TASKS_FILE{.tmp,}
+  grep -v task_bar $EXAMPLE_TASK_FILE > $EXAMPLE_TASK_FILE.tmp
+  mv $EXAMPLE_TASK_FILE{.tmp,}
 
-  run $DRIVER_VALIDATE_TASKS_FILE $EXAMPLE_TASKS_FILE
+  run $DRIVER_VALIDATE_TASK_FILE $EXAMPLE_TASK_FILE
   assert_failure
 }
 

--- a/test/task-runner.bats
+++ b/test/task-runner.bats
@@ -4,7 +4,7 @@ setup() {
   export PROJECT_DIR=$TASK_MASTER_HOME/test/runner-proj
   mkdir -p $PROJECT_DIR
 
-  echo "UUID_runner-proj=$PROJECT_DIR #TEST REMOVE ME" > "$TASK_MASTER_HOME/state/locations.vars"
+  echo "UUID_runner-proj=$PROJECT_DIR #TEST REMOVE ME" >> "$TASK_MASTER_HOME/state/locations.vars"
 
   cat > $PROJECT_DIR/tasks.sh <<EOF
 
@@ -55,7 +55,7 @@ EOF
 DRIVER_EXECUTE_TASK=execute_test
 DRIVER_LIST_TASKS=list_test
 DRIVER_HELP_TASK=help_test
-DRIVER_VALIDATE_TASKS_FILE="not used in task runner"
+DRIVER_VALIDATE_TASK_FILE="not used in task runner"
 
 execute_test() {
   echo I am executing: \$@
@@ -80,7 +80,7 @@ teardown() {
 
   rm -r $DRIVER_TEST_DIR
   awk '/TEST REMOVE ME/ { next } { print }' $DRIVER_DIR/driver_defs.sh > $DRIVER_DIR/driver_defs.sh.tmp && mv $DRIVER_DIR/driver_defs.sh{.tmp,}
-  awk '/TEST REMOVE ME/ { next } { print }' $TASK_MASTER_HOME/state/locations.vars > $TASK_MASTER_HOME/state/locations.vars.tmp && mv $D$TASK_MASTER_HOME/state/locations.vars{.tmp,}
+  awk '/TEST REMOVE ME/ { next } { print }' $TASK_MASTER_HOME/state/locations.vars > $TASK_MASTER_HOME/state/locations.vars.tmp && mv $TASK_MASTER_HOME/state/locations.vars{.tmp,}
   rm $DRIVER_DIR/test_custom_driver.sh
 }
 
@@ -129,7 +129,7 @@ teardown() {
   source $TASK_MASTER_HOME/task-runner.sh
   cd $PROJECT_DIR
 
-  awk '/TEST REMOVE ME/ { next } { print }' $TASK_MASTER_HOME/state/locations.vars > $TASK_MASTER_HOME/state/locations.vars.tmp && mv $D$TASK_MASTER_HOME/state/locations.vars{.tmp,}
+  awk '/TEST REMOVE ME/ { next } { print }' $TASK_MASTER_HOME/state/locations.vars > $TASK_MASTER_HOME/state/locations.vars.tmp && mv $TASK_MASTER_HOME/state/locations.vars{.tmp,}
 
   if [[ -d "$TASK_MASTER_HOME/state/runner-proj" ]]
   then


### PR DESCRIPTION
Standardize variables with the following rules:

1. All multi-word variables have underscores between each word. If there is ambiguity, prefer to split

2. Avoid plural words, unless the variable refers to multiple things

3. Variable type name standards

    a. Space separated strings end in S
    b. Associative arrays end in DICT
    c. Files end in FILE
    d. Directories end in DIR
    e. Regexes end in REG

5. All variables able to be used in tasks are uppercase

6. Minimize/formalize possible variable conflicts by:

* Reducing variable footprint
* Make all builtin tasks/functions readonly (should warn user if a conflict occurs)